### PR TITLE
raman/issue-10 ; Added logic to define userdefine gates in the backend

### DIFF
--- a/backend/jsonClass.py
+++ b/backend/jsonClass.py
@@ -5,6 +5,7 @@ from qutip.qip import *
 import qutip.qip.circuit
 import numpy as np
 from IPython.display import Image
+from userDefinedGates import *
 
 class Manager:
 
@@ -13,8 +14,6 @@ class Manager:
 		self.json_str=json_str
 		self.gate_dict=json.loads(self.json_str)
 
-
-	
 
 class CircuitCreator:
 	
@@ -26,10 +25,19 @@ class CircuitCreator:
 		self.gate_list=[]
 		for gate_dict in self.json_dict["instructions"]:
 			self.gate_list.append(Gate(gate_dict))	
+			#print("------- Individual Gate Matrix of Gate : "+self.gate_list[len(self.gate_list)-1].gate_name+"----------")
+			#print(self.gate_list[len(self.gate_list)-1].OperatorMatrix())
 
 		self.qutip_circuit=QubitCircuit(input_lines,reverse_states=False)
+		num_lines=input_lines
+		self.qutip_circuit.user_gates={"X":PauliX, "Y":PauliY, "Z":PauliZ }
 		for gate in self.gate_list:
 			self.qutip_circuit.add_gate(gate.gate)
+			'''
+			if gate.isUserDefined:
+				self.qutip_circuit.U_list.append(gate.OperatorMatrix())
+				print("RAMAN GateName : "+gate.gate_name)
+			'''
 
 	def OperatorMatrix(self):
 		return gate_sequence_product(self.qutip_circuit.propagators())
@@ -54,6 +62,7 @@ class CircuitCreator:
 class Gate:
 
 	def __init__(self,gate_dict):
+		self.isUserDefined=False
 		self.gate_dict=gate_dict
 		print("===========================")
 		print(self.gate_dict)
@@ -64,8 +73,14 @@ class Gate:
 
 	def ConstructGate(self):
 		self.gate_name=self.gate_dict["name"]
+		self.isUserDefined=UserDefined(self.gate_name)
+		print("Sehgal GATENAME : "+self.gate_name)
 		if(self.gate_name=="CCNOT"):
 			self.gate_name="TOFFOLI"
+		if(self.gate_name=="CSWAP"):
+			self.gate_name="FREDKIN"
+		if(self.gate_name=="H"):
+			self.gate_name="SNOT"
 		self.num_bits=self.gate_dict["num_bits"]
 		self.ctl_bits=self.gate_dict["ctl_bits"]
 		if(self.ctl_bits=="None"):
@@ -86,7 +101,10 @@ class Gate:
 		'''
 		#self.valid_gate=self.CheckGateValidity(self.gate_name)
 		#if(self.valid_gate):
-		
+		#self.qc=QubitCircuit(num_lines)#self.num_bits)
+		self.qc=QubitCircuit(self.num_bits)
+		self.qc.user_gates={"X":PauliX, "Y":PauliY, "Z":PauliZ }
+
 		'''
 		if(self.ctl_enabled==1):
 			if(self.arg_enabled==1):
@@ -135,16 +153,45 @@ def main():
 				]}'
 
 	'''
+	'''
+	gateJson = '{\
+				 "header":{},\
+				 "config":{},\
+				 "instructions":[\
+				 {"name":"H", "num_bits":1, "ctl_enabled" : 0, "ctl_bits" : "None","tgt_bits" : [0], "arg_enabled" : 0, "arg_value" : "None"},\
+				 {"name":"H", "num_bits":1, "ctl_enabled" : 0, "ctl_bits" : "None","tgt_bits" : [0], "arg_enabled" : 0, "arg_value" : "None"},\
+				 {"name":"X", "num_bits":1, "ctl_enabled" : 0, "ctl_bits" : "None", "tgt_bits" : [0], "arg_enabled" : 0, "arg_value" : "None", "rowid" : 2, "columnid" : 4},\
+				 {"name":"X", "num_bits":1, "ctl_enabled" : 0, "ctl_bits" : "None", "tgt_bits" : [0], "arg_enabled" : 0, "arg_value" : "None", "rowid" : 2, "columnid" : 4}\
+				 ]}'
+	'''
+	
+	
 	#New JSON to take care of single input gates as well as gate that accept arg_values
 	gateJson = '{\
 				 "header":{},\
 				 "config":{},\
 				 "instructions":[\
+				 {"name":"H", "num_bits":1, "ctl_enabled" : 0, "ctl_bits" : "None","tgt_bits" : [0], "arg_enabled" : 0, "arg_value" : "None"},\
 				 {"name":"RX", "num_bits":1, "ctl_enabled" : 0, "ctl_bits" : "None","tgt_bits" : [0], "arg_enabled" : 1, "arg_value" : 1.57},\
 				 {"name":"RY", "num_bits":1, "ctl_enabled" : 0, "ctl_bits" : "None","tgt_bits" : [1], "arg_enabled" : 1, "arg_value" : 1.2},\
-				 {"name":"CNOT", "num_bits":2, "ctl_enabled" : 1, "ctl_bits" : [1], "tgt_bits" : [0], "arg_enabled" : 0, "arg_value" : "None"},\
-				 {"name":"SWAP", "num_bits":2, "ctl_enabled" : 0, "ctl_bits" : "None", "tgt_bits" : [0,1], "arg_enabled" : 0, "arg_value" : "None"}\
+				 {"name":"RZ", "num_bits":1, "ctl_enabled" : 0, "ctl_bits" : "None","tgt_bits" : [2], "arg_enabled" : 1, "arg_value" : 1.34},\
+				 {"name":"SQRTNOT", "num_bits":1, "ctl_enabled" : 0, "ctl_bits" : "None","tgt_bits" : [2], "arg_enabled" : 0, "arg_value" : "None"},\
+				 {"name":"PHASEGATE", "num_bits":1, "ctl_enabled" : 0, "ctl_bits" : "None","tgt_bits" : [2], "arg_enabled" : 1, "arg_value" : 0.34},\
+				 {"name":"CPHASE", "num_bits":2, "ctl_enabled" : 1, "ctl_bits" : [2],"tgt_bits" : [0], "arg_enabled" : 1, "arg_value" : 0.87},\
+				 {"name":"FREDKIN", "num_bits":3, "ctl_enabled" : 1, "ctl_bits" : [0],"tgt_bits" : [1,2], "arg_enabled" : 0, "arg_value" : "None"},\
+				 {"name":"CSIGN", "num_bits":2, "ctl_enabled" : 1, "ctl_bits" : [0],"tgt_bits" : [1], "arg_enabled" : 0, "arg_value" : "None"},\
+				 {"name":"CNOT", "num_bits":2, "ctl_enabled" : 1, "ctl_bits" : [0], "tgt_bits" : [1], "arg_enabled" : 0, "arg_value" : "None"},\
+				 {"name":"SWAP", "num_bits":2, "ctl_enabled" : 0, "ctl_bits" : "None", "tgt_bits" : [0,1], "arg_enabled" : 0, "arg_value" : "None"},\
+				 {"name":"CSWAP", "num_bits":3, "ctl_enabled" : 1, "ctl_bits" : [0], "tgt_bits" : [1,2], "arg_enabled" : 0, "arg_value" : "None", "rowid" : 2, "columnid" : 3},\
+				 {"name":"CRX", "num_bits":2, "ctl_enabled" : 1, "ctl_bits" : [0], "tgt_bits" : [1], "arg_enabled" : 1, "arg_value" : 0, "rowid" : 2, "columnid" : 3},\
+				 {"name":"CRY", "num_bits":2, "ctl_enabled" : 1, "ctl_bits" : [0], "tgt_bits" : [1], "arg_enabled" : 1, "arg_value" : 0, "rowid" : 2, "columnid" : 3},\
+				 {"name":"X", "num_bits":1, "ctl_enabled" : 0, "ctl_bits" : "None", "tgt_bits" : [0], "arg_enabled" : 0, "arg_value" : "None", "rowid" : 2, "columnid" : 4},\
+				 {"name":"Y", "num_bits":1, "ctl_enabled" : 0, "ctl_bits" : "None", "tgt_bits" : [1], "arg_enabled" : 0, "arg_value" : "None", "rowid" : 2, "columnid" : 4},\
+				 {"name":"BERKELEY", "num_bits":2, "ctl_enabled" : 0, "ctl_bits" : "None", "tgt_bits" : [1,2], "arg_enabled" : 0, "arg_value" : 0},\
+				 {"name":"TOFFOLI", "num_bits":3, "ctl_enabled" : 1, "ctl_bits" : [0,2], "tgt_bits" : [1], "arg_enabled" : 0, "arg_value" : "None"},\
+				 {"name":"ISWAP", "num_bits":2, "ctl_enabled" : 0, "ctl_bits" : "None", "tgt_bits" : [1,2], "arg_enabled" : 0, "arg_value" : 0}\
 				 ]}'
+	
 	'''
 	#Tested
 	gateJson = '{\
@@ -171,8 +218,8 @@ def main():
 				 ]}'
 	'''
 	#gate=
-	circCreator=CircuitCreator(gateJson,3)
-	print(circCreator.gate_list[0].OperatorMatrix())
+	circCreator=CircuitCreator(gateJson,4)
+	#print(circCreator.gate_list[0].OperatorMatrix())
 	#print(circCreator.gate_list[1].OperatorMatrix())
 	
 	print(circCreator.OperatorMatrix())

--- a/backend/userDefinedGates.py
+++ b/backend/userDefinedGates.py
@@ -1,0 +1,45 @@
+from qutip.qip.circuit import Gate
+from qutip import  sigmax,sigmay,sigmaz
+from qutip import Qobj
+import numpy as numpy
+import qutip.qip.circuit
+from qutip import *
+
+user_defined_gates=["X","Y","Z"]
+def UserDefined(name):
+	return (name in user_defined_gates)
+
+
+def PauliX():
+	return sigmax()
+
+def PauliY():
+	return sigmay()
+
+def PauliZ():
+	return sigmaz()
+
+qc = QubitCircuit(2,reverse_states=False)
+qc.user_gates={"X":PauliX, "Y":PauliY, "Z":PauliZ }
+
+def main():
+	h_gate=Gate("SNOT",targets=[0])
+	qc.add_gate(h_gate)
+	x_gate=Gate("X",targets=[1])
+	qc.add_gate(x_gate)
+	mat=qc.propagators()[0]
+	print(mat)
+	zero=basis(2,0)
+	one=basis(2,1)
+	input=tensor(zero,zero)
+	print("====== Input ========")
+	print(input)
+	print("====== Result =======")
+	res=mat*input
+
+	print(res)
+	qc.png
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
[Issue-10]; Added provision to allow user to add user defined gates in backend

	    Demo is shown in userDefinedGates.py where we tried to create PauliX,
	    PauliY and PauliZ gate, because these gate are present as operators
	    in qutip, and we want them to be defined as gates.

	    Added logic to create Hadamard gate.

	    Tested the code with various other gates as mentioned in the JSON string.

	    Now able to create most of the gates.